### PR TITLE
Add support for Gitlab CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
         shell: /bin/bash
         environment: 
           COMMIT_RANGE: <<pipeline.git.base_revision>>..<<pipeline.git.revision>>
+          CI_COMMIT_BEFORE_SHA: <<pipeline.git.base_revision>>
+          CI_COMMIT_SHA: <<pipeline.git.revision>>
         command: |
           chmod +x ./build.sh
           ./build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
         COMMIT_RANGE: "${{github.event.before}}..${{github.sha}}"
         # Compatibility for CircleCI 2.0
         CIRCLE_SHA1: ${{github.sha}}
+        CI_COMMIT_BEFORE_SHA: "${{github.event.before}}"
+        CI_COMMIT_SHA: "${{github.sha}}"
       shell: bash
       run: |
         chmod +x ./build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.idea
+# File generated while running on local
+builtlist
+/dockerfile*
+# Gitlab Local Run
+builds

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+variables:
+  DOCKER_TLS_CERTDIR: ""
+
+stages:
+  - build
+
+docker-build:
+  image: docker:19.03.1
+  services:
+    - docker:19.03.1-dind
+  stage: build
+  script:
+    - apk update && apk add -y --no-cache bash git # This line can be packaged inside some custom image
+    - chmod +x build.sh && ./build.sh


### PR DESCRIPTION
1. Add support for Gitlab CI (see .gitlab.ci.yml)
2. Cleanup build.sh.
- Use `realpath` instead of `readlink -e`. `realpath` work pretty the
  same on OSX, Ubuntu, Alpine
- Resolve: The very first commit may cause error.
- `CI_COMMIT_BEFORE_SHA`, `CI_COMMIT_SHA` will be put inside pipeline
  and might be re-calculate if needed.